### PR TITLE
Clean.relative import

### DIFF
--- a/rest_framework_elasticsearch/es_views.py
+++ b/rest_framework_elasticsearch/es_views.py
@@ -3,10 +3,10 @@ from __future__ import (absolute_import, division, print_function, unicode_liter
 
 from rest_framework import views
 
-from rest_framework_elasticsearch import es_mixins
+from .es_mixins import ListElasticMixin
 
 
-class ListElasticAPIView(es_mixins.ListElasticMixin,
+class ListElasticAPIView(ListElasticMixin,
                          views.APIView):
     """
     Concrete view for listing a queryset.

--- a/rest_framework_elasticsearch/es_views.py
+++ b/rest_framework_elasticsearch/es_views.py
@@ -13,4 +13,3 @@ class ListElasticAPIView(ListElasticMixin,
     """
     def get(self, request, *args, **kwargs):
         return self.list(request, *args, **kwargs)
-


### PR DESCRIPTION
I think that relative import is considered best practice in django apps. 
Also removing a blank line at end of file (pep8)