### PR TITLE
Remove None values from gte/lte range filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,16 @@ class BlogView(es_views.ListElasticAPIView):
     es_paginator_class = es_pagination.ElasticLimitOffsetPagination
     es_filter_backends = (
         es_filters.ElasticFieldsFilter,
+        es_filters.ElasticFieldsRangeFilter,
         es_filters.ElasticSearchFilter,
         es_filters.ElasticOrderingFilter,
     )
     es_ordering = 'created_at'
     es_filter_fields = (
         es_filters.ESFieldFilter('tag', 'tags'),
+    )
+    es_range_filter_fields = (
+        es_filters.ESFieldFilter('created_at', 'created_at'),
     )
     es_search_fields = (
         'tags',
@@ -74,6 +78,7 @@ This will allow the client to filter the items in the list by making queries suc
 http://example.com/blogs/api/list?search=elasticsearch
 http://example.com/blogs/api/list?tag=opensource
 http://example.com/blogs/api/list?tag=opensource,aws
+http://example.com/blogs/api/list?to_created_at=2020-10-01&from_created_at=2017-09-01
 ```
 
 ## Documentation

--- a/rest_framework_elasticsearch/__init__.py
+++ b/rest_framework_elasticsearch/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'rest_framework_elasticsearch'
-__version__ = '0.3.2'
+__version__ = '0.3.3'
 __author__ = 'Yaroslav Muravskyi'
 
 # Version synonym

--- a/rest_framework_elasticsearch/es_filters.py
+++ b/rest_framework_elasticsearch/es_filters.py
@@ -120,10 +120,17 @@ class ElasticFieldsRangeFilter(ElasticFieldsFilter):
                     field,
                     request.query_params.get('to_{}'.format(item.label),'').strip()
                 )
-                search = search.filter(
-                    'range',
-                    **{item.name: {'gte': from_arg, 'lte': to_arg}}
-                )
+
+                options = {}
+                if from_arg:
+                    options['gte'] = from_arg
+                if to_arg:
+                    options['lte'] = to_arg
+                if options:
+                    search = search.filter(
+                        'range',
+                        **{item.name: options}
+                    )
         return search
 
 


### PR DESCRIPTION
Elasticsearch finds nothing when None is passed to gte/lte in the range filter. This pull request changes behaviour so that it does not pass None if the filter value is undefined.