### PR TITLE
ES AutoSchema for filter backends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ ENV/
 
 # PyCharm
 .idea/
+
+# VSCODE
+.vscode/

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ from rest_framework_elasticsearch import es_views, es_pagination, es_filters
 class BlogView(es_views.ListElasticAPIView):
     es_client = es_client
     es_model = BlogIndex
-    es_paginator_class = es_pagination.ElasticLimitOffsetPagination
+    es_pagination_class = es_pagination.ElasticLimitOffsetPagination
     es_filter_backends = (
         es_filters.ElasticFieldsFilter,
         es_filters.ElasticFieldsRangeFilter,

--- a/docs/ordering.rst
+++ b/docs/ordering.rst
@@ -12,7 +12,7 @@ Example of ordering
         es_client = Elasticsearch(hosts=['elasticsearch:9200/'],
                                   connection_class=RequestsHttpConnection)
 
-        es_paginator_class = es_pagination.ElasticLimitOffsetPagination
+        es_pagination_class = es_pagination.ElasticLimitOffsetPagination
 
         es_filter_backends = (
             es_filters.ElasticFieldsFilter,

--- a/docs/pagination.rst
+++ b/docs/pagination.rst
@@ -12,7 +12,7 @@ Example of the pagination response
         es_client = Elasticsearch(hosts=['elasticsearch:9200/'],
                                   connection_class=RequestsHttpConnection)
 
-        es_paginator_class = es_pagination.ElasticLimitOffsetPagination
+        es_pagination_class = es_pagination.ElasticLimitOffsetPagination
 
         es_model = BlogIndex
         es_filter_backends = (

--- a/example_project/config/urls.py
+++ b/example_project/config/urls.py
@@ -8,21 +8,26 @@ from django.contrib import admin
 from django.views import defaults as default_views
 from django.views.generic import TemplateView
 
+from rest_framework.documentation import include_docs_urls
+
+
 urlpatterns = [
-                  url(r'^$', TemplateView.as_view(template_name='pages/home.html'), name='home'),
-                  url(r'^about/$', TemplateView.as_view(template_name='pages/about.html'), name='about'),
+    url(r'^$', TemplateView.as_view(template_name='pages/home.html'), name='home'),
+    url(r'^about/$', TemplateView.as_view(template_name='pages/about.html'), name='about'),
 
-                  # Django Admin, use {% url 'admin:index' %}
-                  url(settings.ADMIN_URL, admin.site.urls),
+    # Django Admin, use {% url 'admin:index' %}
+    url(settings.ADMIN_URL, admin.site.urls),
 
-                  # User management
-                  url(r'^users/', include('example_project.users.urls', namespace='users')),
-                  url(r'^blogs/', include('example_project.blog.urls', namespace='users')),
-                  url(r'^accounts/', include('allauth.urls')),
+    # User management
+    url(r'^users/', include('example_project.users.urls', namespace='users')),
+    url(r'^blogs/', include('example_project.blog.urls', namespace='users')),
+    url(r'^accounts/', include('allauth.urls')),
 
-                  # Your stuff: custom urls includes go here
+    # API Docs
+    url(r'^docs/', include_docs_urls(title='Example Project', public=False)),
 
-              ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    # Your stuff: custom urls includes go here
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 if settings.DEBUG:
     # This allows the error pages to be debugged during development, just visit

--- a/example_project/example_project/blog/views.py
+++ b/example_project/example_project/blog/views.py
@@ -7,7 +7,7 @@ from .search_indexes import BlogIndex
 class BlogView(es_views.ListElasticAPIView):
     es_client = es_client
     es_model = BlogIndex
-    es_paginator_class = es_pagination.ElasticLimitOffsetPagination
+    es_pagination_class = es_pagination.ElasticLimitOffsetPagination
 
     es_filter_backends = (
         es_filters.ElasticFieldsFilter,

--- a/example_project/requirements/base.txt
+++ b/example_project/requirements/base.txt
@@ -44,8 +44,10 @@ django-redis==4.7.0
 redis>=2.10.5
 
 # Django Rest Framework
-djangorestframework==3.6.2
+djangorestframework==3.7.1
 django-filter==1.0.1
 django-rest-elasticsearch==0.3.2
+coreapi==2.3.3
+coreschema==0.0.4
 
 # Your custom requirements go here

--- a/rest_framework_elasticsearch/es_filters.py
+++ b/rest_framework_elasticsearch/es_filters.py
@@ -3,16 +3,21 @@ from __future__ import (absolute_import, division, print_function, unicode_liter
 from functools import reduce
 
 from django.utils import six
+from django.utils.encoding import force_text
+from django.utils.translation import ugettext_lazy as _
 from elasticsearch_dsl import Q, ValidationException
 
 from rest_framework import filters
 from rest_framework.settings import api_settings
+from rest_framework.compat import coreapi, coreschema
 
 
 class ESFieldFilter(object):
-    def __init__(self, label, name=None):
+    def __init__(self, label, name=None, description=None):
         self.label = label
         self._name = name
+        # API docs filter description
+        self.description = description
 
     @property
     def name(self):
@@ -21,7 +26,25 @@ class ESFieldFilter(object):
         return self._name
 
 
-class ElasticOrderingFilter(filters.OrderingFilter):
+class BaseEsFilterBackend(object):
+    """
+    A base class from Elastycsearch filter backend classes.
+    """
+
+    def filter_search(self, request, search, view):
+        """
+        Return a filtered search.
+        """
+        raise NotImplementedError(".filter_search() must be overridden.")
+
+    def get_schema_fields(self, view):
+        assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
+        assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
+        return []
+
+
+class ElasticOrderingFilter(filters.OrderingFilter, BaseEsFilterBackend):
+
     def get_default_ordering(self, view):
         ordering = getattr(view, 'es_ordering', None)
         if isinstance(ordering, six.string_types):
@@ -49,7 +72,9 @@ class ElasticOrderingFilter(filters.OrderingFilter):
         return search
 
 
-class ElasticFieldsFilter(object):
+class ElasticFieldsFilter(BaseEsFilterBackend):
+    filter_description = _('A filter term.')
+
     @staticmethod
     def clean_field(field, data):
         # Hook for validate bolean
@@ -79,64 +104,87 @@ class ElasticFieldsFilter(object):
                 return
         return data
 
+    def get_es_filter_fields(self, view):
+        return getattr(view, 'es_filter_fields', tuple())
+
     def filter_search(self, request, search, view):
-        es_filter_fields = getattr(view, 'es_filter_fields', None)
         es_model = getattr(view, 'es_model', None)
-        if es_filter_fields:
-            for item in es_filter_fields:
-                try:
-                    field = reduce(lambda d, key: d[key] if d else None,
-                                   item.name.split('.'), es_model._doc_type.mapping)
-                except KeyError:
-                    # Incorrect field
-                    continue
-                args = request.query_params.get(item.label, '')
-                data = [self.clean_field(field, value.strip()) for value in args.split(',')]
-                # Remove empty string and None values
-                data = [value for value in data
-                        if value is not None and value is not '']
-                if data:
-                    search = search.filter('terms', **{item.name: data})
+        for item in self.get_es_filter_fields(view):
+            try:
+                field = reduce(lambda d, key: d[key] if d else None,
+                               item.name.split('.'), es_model._doc_type.mapping)
+            except KeyError:
+                # Incorrect field
+                continue
+            args = request.query_params.get(item.label, '')
+            data = [self.clean_field(field, value.strip()) for value in args.split(',')]
+            # Remove empty string and None values
+            data = [value for value in data
+                    if value is not None and value is not '']
+            if data:
+                search = search.filter('terms', **{item.name: data})
         return search
+
+    def get_schema_fields(self, view):
+        assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
+        assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
+        fields = []
+        for item in self.get_es_filter_fields(view):
+            field = coreapi.Field(
+                name=item.label,
+                required=False,
+                location='query',
+                schema=coreschema.String(
+                    title=force_text(item.label),
+                    description=force_text(item.description or self.filter_description)
+                )
+            )
+            fields.append(field)
+
+        return fields
 
 
 class ElasticFieldsRangeFilter(ElasticFieldsFilter):
-    def filter_search(self, request, search, view):
-        es_filter_fields = getattr(view, 'es_range_filter_fields', None)
-        es_model = getattr(view, 'es_model', None)
-        if es_filter_fields:
-            for item in es_filter_fields:
-                try:
-                    field = reduce(lambda d, key: d[key] if d else None,
-                                   item.name.split('.'), es_model._doc_type.mapping)
-                except KeyError:
-                    # Incorrect field
-                    continue
-                from_arg = self.clean_field(
-                    field,
-                    request.query_params.get('from_{}'.format(item.label),'').strip()
-                )
-                to_arg = self.clean_field(
-                    field,
-                    request.query_params.get('to_{}'.format(item.label),'').strip()
-                )
 
-                options = {}
-                if from_arg:
-                    options['gte'] = from_arg
-                if to_arg:
-                    options['lte'] = to_arg
-                if options:
-                    search = search.filter(
-                        'range',
-                        **{item.name: options}
-                    )
+    def get_es_filter_fields(self, view):
+        return getattr(view, 'es_range_filter_fields', tuple())
+
+    def filter_search(self, request, search, view):
+        es_model = getattr(view, 'es_model', None)
+        for item in self.get_es_filter_fields(view):
+            try:
+                field = reduce(lambda d, key: d[key] if d else None,
+                               item.name.split('.'), es_model._doc_type.mapping)
+            except KeyError:
+                # Incorrect field
+                continue
+            from_arg = self.clean_field(
+                field,
+                request.query_params.get('from_{}'.format(item.label), '').strip()
+            )
+            to_arg = self.clean_field(
+                field,
+                request.query_params.get('to_{}'.format(item.label), '').strip()
+            )
+
+            options = {}
+            if from_arg:
+                options['gte'] = from_arg
+            if to_arg:
+                options['lte'] = to_arg
+            if options:
+                search = search.filter(
+                    'range',
+                    **{item.name: options}
+                )
         return search
 
 
-class ElasticSearchFilter(object):
+class ElasticSearchFilter(BaseEsFilterBackend):
     search_param = api_settings.SEARCH_PARAM
     search_should_match = '75%'
+    search_title = _('Search')
+    search_description = _('A search term.')
 
     def get_search_query(self, request):
         """
@@ -155,3 +203,18 @@ class ElasticSearchFilter(object):
         search = search.query(q)
         search.query.minimum_should_match = self.search_should_match
         return search
+
+    def get_schema_fields(self, view):
+        assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
+        assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
+        return [
+            coreapi.Field(
+                name=self.search_param,
+                required=False,
+                location='query',
+                schema=coreschema.String(
+                    title=force_text(self.search_title),
+                    description=force_text(self.search_description)
+                )
+            )
+        ]

--- a/rest_framework_elasticsearch/es_inspector.py
+++ b/rest_framework_elasticsearch/es_inspector.py
@@ -1,0 +1,36 @@
+from rest_framework.schemas import AutoSchema
+from rest_framework.schemas.utils import is_list_view
+
+
+class EsAutoSchema(AutoSchema):
+    """ Elasticsearch inspector for APIView
+
+    Responsible for per-view instrospection and schema generation.
+    """
+
+    def get_es_filter_fields(self, path, method):
+        fields = []
+        for filter_backend in self.view.es_filter_backends:
+            fields += filter_backend().get_schema_fields(self.view)
+        return fields
+
+    def get_filter_fields(self, path, method):
+        fields = super(EsAutoSchema, self).get_filter_fields(path, method)
+        fields += self.get_es_filter_fields(path, method)
+        return fields
+
+    def get_es_pagination_fields(self, path, method):
+        view = self.view
+        if not is_list_view(path, method, view):
+            return []
+
+        pagination = getattr(view, 'es_pagination_class', None)
+        if not pagination:
+            return []
+
+        return pagination().get_schema_fields(view)
+
+    def get_pagination_fields(self, path, method):
+        fields = super(EsAutoSchema, self).get_pagination_fields(path, method)
+        fields += self.get_es_pagination_fields(path, method)
+        return fields

--- a/rest_framework_elasticsearch/es_mixins.py
+++ b/rest_framework_elasticsearch/es_mixins.py
@@ -6,15 +6,19 @@ from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search
 from rest_framework.response import Response
 
+from .es_inspector import EsAutoSchema
+
 
 class ListElasticMixin(object):
     es_client = None
 
     es_model = None
-    es_paginator_class = None
+    es_pagination_class = None
 
     es_filter_backends = ()
     es_excludes_fields = ()
+
+    schema = EsAutoSchema()
 
     def get_es_client(self):
         """
@@ -67,7 +71,7 @@ class ListElasticMixin(object):
         The es_paginator instance associated with the view
         """
         if not hasattr(self, '_es_paginator'):
-            if self.es_paginator_class is None:
+            if self.es_pagination_class is None:
                 self._es_paginator = None
             else:
                 self._es_paginator = self.es_paginator_class()

--- a/rest_framework_elasticsearch/es_mixins.py
+++ b/rest_framework_elasticsearch/es_mixins.py
@@ -74,7 +74,7 @@ class ListElasticMixin(object):
             if self.es_pagination_class is None:
                 self._es_paginator = None
             else:
-                self._es_paginator = self.es_paginator_class()
+                self._es_paginator = self.es_pagination_class()
         return self._es_paginator
 
     def paginate_search(self, search):


### PR DESCRIPTION
Added support **django-rest-elasticsearch** filters and pagination class for **DRF** coreschema api generation.

<img width="1435" alt="screen shot 2017-11-26 at 12 53 48 pm" src="https://user-images.githubusercontent.com/11655110/33239496-8f116380-d2ab-11e7-9385-a667144e08f7.png">
<img width="1422" alt="screen shot 2017-11-26 at 12 54 08 pm" src="https://user-images.githubusercontent.com/11655110/33239497-8f31de1c-d2ab-11e7-9274-70e1faf39efd.png">
