### PR TITLE
Fix ElasticFieldsRangeFilter to use user defined list

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ class BlogView(es_views.ListElasticAPIView):
         es_filters.ESFieldFilter('tag', 'tags'),
     )
     es_range_filter_fields = (
-        es_filters.ESFieldFilter('created_at', 'created_at'),
+        es_filters.ESFieldFilter('created_at'),
     )
     es_search_fields = (
         'tags',

--- a/rest_framework_elasticsearch/es_views.py
+++ b/rest_framework_elasticsearch/es_views.py
@@ -39,7 +39,7 @@ class ElasticAPIView(views.APIView):
         Return field or fields used for search filtering by range.
         The return value must be an iterable.
         """
-        return getattr(self, 'es_filter_fields', tuple())
+        return getattr(self, 'es_range_filter_fields', tuple())
 
     def get_es_ordering_fields(self):
         """

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -252,7 +252,7 @@ class TestElasticFieldsRangeFilter:
         """
         view = ElasticAPIView()
         view.es_model = DataDocType
-        view.es_filter_fields = es_range_filter_fields
+        view.es_range_filter_fields = es_range_filter_fields
         return view
 
     def test_get_es_filter_fields(self):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -59,9 +59,9 @@ class TestElasticAPIView:
         view = ElasticAPIView()
         assert view.get_es_range_filter_fields() == tuple()
 
-        es_filter_fields = ('first_name', 'last_name')
-        view.es_filter_fields = es_filter_fields
-        assert view.get_es_range_filter_fields() == es_filter_fields
+        es_range_filter_fields = ('first_name', 'last_name')
+        view.es_range_filter_fields = es_range_filter_fields
+        assert view.get_es_range_filter_fields() == es_range_filter_fields
 
     def test_get_es_ordering_fields(self):
         view = ElasticAPIView()


### PR DESCRIPTION
`get_es_range_filter_fields()` was incorrectly using `es_filter_fields` instead of `es_range_filter_fields`