### PR TITLE
Elasticsearch 7 compatibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       context: ./
       dockerfile: ./compose/python/Dockerfile
     volumes:
-      - .:/app/src            
+      - .:/app/src:ro
 
     depends_on:
       - elasticsearch

--- a/rest_framework_elasticsearch/es_pagination.py
+++ b/rest_framework_elasticsearch/es_pagination.py
@@ -11,8 +11,7 @@ class ElasticLimitOffsetPagination(LimitOffsetPagination):
     default_limit = 10
 
     def _get_count(self, search):
-        response = search.execute()
-        return response.hits.total
+        return search.count()
 
     def paginate_search(self, search, request, view=None):
         """

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -29,7 +29,6 @@ def create_test_index():
 DATA = [
     {
         '_index': 'test',
-        '_type': 'doc',
         '_id': '1',
         '_source': {
             'first_name': 'Zofia',
@@ -50,7 +49,6 @@ DATA = [
     },
     {
         '_index': 'test',
-        '_type': 'doc',
         '_id': '2',
         '_source': {
             'first_name': 'Callisto',
@@ -71,7 +69,6 @@ DATA = [
     },
     {
         '_index': 'test',
-        '_type': 'doc',
         '_id': '3',
         '_source': {
             'first_name': 'Samantha',
@@ -93,7 +90,6 @@ DATA = [
     },
     {
         '_index': 'test',
-        '_type': 'doc',
         '_id': '4',
         '_source': {
             'first_name': 'Crocetta',
@@ -115,7 +111,6 @@ DATA = [
     },
     {
         '_index': 'test',
-        '_type': 'doc',
         '_id': '5',
         '_source': {
             'first_name': 'Akhmad',
@@ -138,7 +133,6 @@ DATA = [
     },
     {
         '_index': 'test',
-        '_type': 'doc',
         '_id': '6',
         '_source': {
             'first_name': 'Rohan',
@@ -159,7 +153,6 @@ DATA = [
     },
     {
         '_index': 'test',
-        '_type': 'doc',
         '_id': '7',
         '_source': {
             'first_name': 'Odell',
@@ -180,7 +173,6 @@ DATA = [
     },
     {
         '_index': 'test',
-        '_type': 'doc',
         '_id': '8',
         '_source': {
             'first_name': 'Markus',
@@ -201,7 +193,6 @@ DATA = [
     },
     {
         '_index': 'test',
-        '_type': 'doc',
         '_id': '9',
         '_source': {
             'first_name': 'Gabriel',
@@ -222,7 +213,6 @@ DATA = [
     },
     {
         '_index': 'test',
-        '_type': 'doc',
         '_id': '10',
         '_source': {
             'first_name': 'Merilyn',
@@ -243,7 +233,6 @@ DATA = [
     },
     {
         '_index': 'test',
-        '_type': 'doc',
         '_id': '11',
         '_source': {
             'first_name': 'Sunil',
@@ -263,7 +252,6 @@ DATA = [
     },
     {
         '_index': 'test',
-        '_type': 'doc',
         '_id': '12',
         '_source': {
             'first_name': 'Navin',
@@ -284,7 +272,6 @@ DATA = [
     },
     {
         '_index': 'test',
-        '_type': 'doc',
         '_id': '13',
         '_source': {
             'first_name': 'Helga',
@@ -305,7 +292,6 @@ DATA = [
     },
     {
         '_index': 'test',
-        '_type': 'doc',
         '_id': '14',
         '_source': {
             'first_name': 'Lynsey',
@@ -325,6 +311,10 @@ DATA = [
         },
     },
 ]
+
+if es.__version__ < (7, 0, 0):
+    for doc in DATA:
+        doc['_type'] = 'doc'
 
 
 class TestCreateIndex:


### PR DESCRIPTION
All it took for the package to be compatible was the count() instead of using the total. It's possible of course to execute and then use the new total format but I don't see a good reason to do that as the response isn't reused anyway.
The test suite now passes with both ES 6 & 7. I didn't change the version used for testing though.